### PR TITLE
Prefer `File.exist?` over `File.exists?`

### DIFF
--- a/lib/pgp/gpg/temp_path_helper.rb
+++ b/lib/pgp/gpg/temp_path_helper.rb
@@ -15,7 +15,7 @@ module GPG
     private
 
     def self.delete(path)
-      if File.exists?(path)
+      if File.exist?(path)
         File.delete(path)
       end
     end


### PR DESCRIPTION
Ruby 3.2 dropped support for the old alias, so this needs to change now.

See https://bugs.ruby-lang.org/issues/17391